### PR TITLE
Put PASS FAIL first, print INPUT, EXPECTED, ACTUAL per failure

### DIFF
--- a/01_combinational_logic/01_01_mux_question.sv
+++ b/01_combinational_logic/01_01_mux_question.sv
@@ -52,13 +52,13 @@ module testbench;
 
     # 1;
 
-    $display ("TEST d { %h %h %h %h } sel %d y %h",
-        d0, d1, d2, d3, sel, y);
-
     if (y !== ty)
       begin
-        $display ("%s FAIL: %h EXPECTED", `__FILE__, ty);
-        $finish;
+        $display("FAIL %s", `__FILE__);
+        $display("++ INPUT    => {d0:%h, d1:%h, d2:%h, d3:%h, sel:%d}", d0, d1, d2, d3, sel,);
+        $display("++ EXPECTED => {y:%h}", ty);
+        $display("++ ACTUAL   => {y:%h}", y);
+        $fatal(1, "Test Failed");
       end
 
   endtask
@@ -75,7 +75,7 @@ module testbench;
       test (7, 10, 3, 'x, 2, 3);
       test (7, 10, 3, 'x, 3, 'x);
 
-      $display ("%s PASS", `__FILE__);
+      $display ("PASS %s", `__FILE__);
       $finish;
     end
 

--- a/01_combinational_logic/01_02_mux_if.sv
+++ b/01_combinational_logic/01_02_mux_if.sv
@@ -56,13 +56,13 @@ module testbench;
 
     # 1;
 
-    $display ("TEST d { %h %h %h %h } sel %d y %h",
-        d0, d1, d2, d3, sel, y);
-
     if (y !== ty)
       begin
-        $display ("%s FAIL: %h EXPECTED", `__FILE__, ty);
-        $finish;
+        $display("FAIL %s", `__FILE__);
+        $display("++ INPUT    => {d0:%h, d1:%h, d2:%h, d3:%h, sel:%d}", d0, d1, d2, d3, sel,);
+        $display("++ EXPECTED => {y:%h}", ty);
+        $display("++ ACTUAL   => {y:%h}", y);
+        $fatal(1, "Test Failed");
       end
 
   endtask
@@ -79,7 +79,7 @@ module testbench;
       test (7, 10, 3, 'x, 2, 3);
       test (7, 10, 3, 'x, 3, 'x);
 
-      $display ("%s PASS", `__FILE__);
+      $display ("PASS %s", `__FILE__);
       $finish;
     end
 

--- a/01_combinational_logic/01_03_mux_case.sv
+++ b/01_combinational_logic/01_03_mux_case.sv
@@ -61,8 +61,11 @@ module testbench;
 
     if (y !== ty)
       begin
-        $display ("%s FAIL: %h EXPECTED", `__FILE__, ty);
-        $finish;
+        $display("FAIL %s", `__FILE__);
+        $display("++ INPUT    => {d0:%h, d1:%h, d2:%h, d3:%h, sel:%d}", d0, d1, d2, d3, sel,);
+        $display("++ EXPECTED => {y:%h}", ty);
+        $display("++ ACTUAL   => {y:%h}", y);
+        $fatal(1, "Test Failed");
       end
 
   endtask
@@ -79,7 +82,7 @@ module testbench;
       test (7, 10, 3, 'x, 2, 3);
       test (7, 10, 3, 'x, 3, 'x);
 
-      $display ("%s PASS", `__FILE__);
+      $display ("PASS %s", `__FILE__);
       $finish;
     end
 

--- a/01_combinational_logic/01_04_mux_index.sv
+++ b/01_combinational_logic/01_04_mux_index.sv
@@ -57,13 +57,13 @@ module testbench;
 
     # 1;
 
-    $display ("TEST d { %h %h %h %h } sel %d y %h",
-        d0, d1, d2, d3, sel, y);
-
     if (y !== ty)
       begin
-        $display ("%s FAIL: %h EXPECTED", `__FILE__, ty);
-        $finish;
+        $display("FAIL %s", `__FILE__);
+        $display("++ INPUT    => {d0:%h, d1:%h, d2:%h, d3:%h, sel:%d}", d0, d1, d2, d3, sel,);
+        $display("++ EXPECTED => {y:%h}", ty);
+        $display("++ ACTUAL   => {y:%h}", y);
+        $fatal(1, "Test Failed");
       end
 
   endtask
@@ -80,7 +80,7 @@ module testbench;
       test (7, 10, 3, 'x, 2, 3);
       test (7, 10, 3, 'x, 3, 'x);
 
-      $display ("%s PASS", `__FILE__);
+      $display ("PASS %s", `__FILE__);
       $finish;
     end
 

--- a/01_combinational_logic/01_05_mux_gates.sv
+++ b/01_combinational_logic/01_05_mux_gates.sv
@@ -92,8 +92,11 @@ module testbench;
 
     # 1;
 
-    $display ("TEST d { %h %h %h %h } sel %d y %h",
-        d0, d1, d2, d3, sel, y);
+    $display("FAIL %s", `__FILE__);
+    $display("++ INPUT    => {d0:%h, d1:%h, d2:%h, d3:%h, sel:%d}", d0, d1, d2, d3, sel,);
+    $display("++ EXPECTED => {y:%h}", ty);
+    $display("++ ACTUAL   => {y:%h}", y);
+    $fatal(1, "Test Failed");
 
     if (y !== ty)
       begin
@@ -115,7 +118,7 @@ module testbench;
       test (7, 10, 3, 'x, 2, 3);
       test (7, 10, 3, 'x, 3, 'x);
 
-      $display ("%s PASS", `__FILE__);
+      $display ("PASS %s", `__FILE__);
       $finish;
     end
 

--- a/01_combinational_logic/01_06_mux_2n_using_muxes_n.sv
+++ b/01_combinational_logic/01_06_mux_2n_using_muxes_n.sv
@@ -51,13 +51,13 @@ module testbench;
 
     # 1;
 
-    $display ("TEST d { %h %h %h %h } sel %d y %h",
-        d0, d1, d2, d3, sel, y);
-
     if (y !== ty)
       begin
-        $display ("%s FAIL: %h EXPECTED", `__FILE__, ty);
-        $finish;
+        $display("FAIL %s", `__FILE__);
+        $display("++ INPUT    => {d0:%h, d1:%h, d2:%h, d3:%h, sel:%d}", d0, d1, d2, d3, sel,);
+        $display("++ EXPECTED => {y:%h}", ty);
+        $display("++ ACTUAL   => {y:%h}", y);
+        $fatal(1, "Test Failed");
       end
 
   endtask
@@ -74,7 +74,7 @@ module testbench;
       test (7, 10, 3, 'x, 2, 3);
       test (7, 10, 3, 'x, 3, 'x);
 
-      $display ("%s PASS", `__FILE__);
+      $display ("PASS %s", `__FILE__);
       $finish;
     end
 

--- a/01_combinational_logic/01_07_mux_using_narrow_data_muxes.sv
+++ b/01_combinational_logic/01_07_mux_using_narrow_data_muxes.sv
@@ -53,13 +53,13 @@ module testbench;
 
     # 1;
 
-    $display ("TEST d { %h %h %h %h } sel %d y %h",
-        d0, d1, d2, d3, sel, y);
-
     if (y !== ty)
       begin
-        $display ("%s FAIL: %h EXPECTED", `__FILE__, ty);
-        $finish;
+        $display("FAIL %s", `__FILE__);
+        $display("++ INPUT    => {d0:%h, d1:%h, d2:%h, d3:%h, sel:%d}", d0, d1, d2, d3, sel,);
+        $display("++ EXPECTED => {y:%h}", ty);
+        $display("++ ACTUAL   => {y:%h}", y);
+        $fatal(1, "Test Failed");
       end
 
   endtask
@@ -76,7 +76,7 @@ module testbench;
       test (7, 10, 3, 'x, 2, 3);
       test (7, 10, 3, 'x, 3, 'x);
 
-      $display ("%s PASS", `__FILE__);
+      $display ("PASS %s", `__FILE__);
       $finish;
     end
 

--- a/01_combinational_logic/01_08_not_gate_using_mux.sv
+++ b/01_combinational_logic/01_08_not_gate_using_mux.sv
@@ -46,12 +46,15 @@ module testbench;
 
         if (o !== ~ a)
           begin
-            $display ("%s FAIL: %h EXPECTED", `__FILE__, ~ a);
-            $finish;
+            $display("FAIL %s", `__FILE__);
+            $display("++ INPUT    => {a:%h, i:%h}", a, i);
+            $display("++ EXPECTED => {o:%h}", ~a);
+            $display("++ ACTUAL   => {o:%h}", o);
+            $fatal(1, "Test Failed");
           end
       end
 
-      $display ("%s PASS", `__FILE__);
+      $display ("PASS %s", `__FILE__);
       $finish;
     end
 

--- a/01_combinational_logic/01_09_and_gate_using_mux.sv
+++ b/01_combinational_logic/01_09_and_gate_using_mux.sv
@@ -45,16 +45,17 @@ module testbench;
 
         # 1;
 
-        $display ("TEST %b & %b = %b", a, b, o);
-
         if (o !== (a & b))
           begin
-            $display ("%s FAIL: %h EXPECTED", `__FILE__, a & b);
-            $finish;
+            $display("FAIL %s", `__FILE__);
+            $display("++ INPUT    => {a:%h, b:%h, i:%h, j:%h}", a, b, i, j);
+            $display("++ EXPECTED => {o:%h}", a & b);
+            $display("++ ACTUAL   => {o:%h}", o);
+            $fatal(1, "Test Failed");
           end
       end
 
-      $display ("%s PASS", `__FILE__);
+      $display ("PASS %s", `__FILE__);
       $finish;
     end
 

--- a/01_combinational_logic/01_10_or_gate_using_mux.sv
+++ b/01_combinational_logic/01_10_or_gate_using_mux.sv
@@ -49,12 +49,15 @@ module testbench;
 
         if (o !== (a | b))
           begin
-            $display ("%s FAIL: %h EXPECTED", `__FILE__, a | b);
-            $finish;
+            $display("FAIL %s", `__FILE__);
+            $display("++ INPUT    => {a:%h, b:%h, i:%h, j:%h}", a, b, i, j);
+            $display("++ EXPECTED => {o:%h}", a | b);
+            $display("++ ACTUAL   => {o:%h}", o);
+            $fatal(1, "Test Failed");
           end
       end
 
-      $display ("%s PASS", `__FILE__);
+      $display ("PASS %s", `__FILE__);
       $finish;
     end
 

--- a/01_combinational_logic/01_11_xor_gate_using_mux.sv
+++ b/01_combinational_logic/01_11_xor_gate_using_mux.sv
@@ -45,16 +45,18 @@ module testbench;
 
         # 1;
 
-        $display ("TEST %b ^ %b = %b", a, b, o);
-
         if (o !== (a ^ b))
           begin
-            $display ("%s FAIL: %h EXPECTED", `__FILE__, a ^ b);
-            $finish;
+            $display("FAIL %s", `__FILE__);
+            $display("++ INPUT    => {a:%h, b:%h, i:%h, j:%h}", a, b, i, j);
+            $display("++ EXPECTED => {o:%h}", a ^ b);
+            $display("++ ACTUAL   => {o:%h}", o);
+            $fatal(1, "Test Failed");
+
           end
       end
 
-      $display ("%s PASS", `__FILE__);
+      $display ("PASS %s", `__FILE__);
       $finish;
     end
 

--- a/01_combinational_logic/run_all_using_iverilog_under_linux_or_macos_brew.sh
+++ b/01_combinational_logic/run_all_using_iverilog_under_linux_or_macos_brew.sh
@@ -62,4 +62,4 @@ done
 
 rm -f a.out
 
-grep -e PASS -e FAIL -e error log.txt
+grep -e PASS -e FAIL -e error -e ++ log.txt | sed -e 's/PASS/\x1b[0;32m&\x1b[0m/g' -e 's/FAIL/\x1b[0;31m&\x1b[0m/g'


### PR DESCRIPTION
This isn't a complete PR (it only encompasses the first `01_combinatorial_logic` section).

I am proposing that we colorize the PASS & FAIL to make them easier to visually scan.

I am proposing that we move the PASS & FAIL message to the front of each line for easier scanning, so that they align, and so that the file names always start at the same position.

I am also proposing using the $fatal return code to end execution. This should allow us to check in our "all_*" scripts when a particular test fails and choose to short circuit the rest if that occurs. This might be beneficial in not overwhelming students as well as always putting the failing information on the bottom of their console (avoiding scrolling). Short circuiting on non zero status code is not implemented, but should be trivial.

Finally, I am proposing that we add in a ++ as a "pulled from log" value so that we can print the INPUT, EXPECTED, and ACTUAL values from each test. I am structuring them somewhat like Python maps as I think most people are familiar with them.

It looks like the following (I have written passing code for the first 2, and the rest are still failures) =>

![ss](https://github.com/user-attachments/assets/376cb876-69a3-4368-9c5f-c06be837f112)
