### PR TITLE
fixed minor testing issues

### DIFF
--- a/01_combinational_logic/01_05_mux_gates.sv
+++ b/01_combinational_logic/01_05_mux_gates.sv
@@ -92,14 +92,15 @@ module testbench;
 
     # 1;
 
-    $display("FAIL %s", `__FILE__);
-    $display("++ INPUT    => {d0:%h, d1:%h, d2:%h, d3:%h, sel:%d}", d0, d1, d2, d3, sel,);
-    $display("++ EXPECTED => {y:%h}", ty);
-    $display("++ ACTUAL   => {y:%h}", y);
-    $fatal(1, "Test Failed");
+
 
     if (y !== ty)
       begin
+        $display("FAIL %s", `__FILE__);
+        $display("++ INPUT    => {d0:%h, d1:%h, d2:%h, d3:%h, sel:%d}", d0, d1, d2, d3, sel,);
+        $display("++ EXPECTED => {y:%h}", ty);
+        $display("++ ACTUAL   => {y:%h}", y);
+        $fatal(1, "Test Failed");
         $display ("%s FAIL: %h EXPECTED", `__FILE__, ty);
         $finish;
       end


### PR DESCRIPTION
The test script in  01_05_mux_gates was such that it would always trigger a failure since the "failure" code ran without checking if the output was the same as the test. This refactor fixes this.