### PR TITLE
Fix: Double buffer

### DIFF
--- a/08_flow_control/08_07_1_a_plus_b_using_double_buffers/double_buffer_from_dally_harting.sv
+++ b/08_flow_control/08_07_1_a_plus_b_using_double_buffers/double_buffer_from_dally_harting.sv
@@ -22,15 +22,18 @@ module double_buffer_from_dally_harting
     output logic [width - 1:0] down_data
 );
 
+    logic               enable;
     logic               buf_valid;
     logic [width - 1:0] buf_data;
 
+    assign enable = down_ready | ~down_valid;
+
     always_ff @ (posedge clk)
     begin
-        if (up_ready & ~ down_ready)
+        if (up_ready & ~enable)
             buf_data <= up_data;
 
-        if (down_ready)
+        if (enable)
             down_data <= up_ready ? up_data : buf_data;
     end
 
@@ -43,13 +46,13 @@ module double_buffer_from_dally_harting
         end
         else
         begin
-            if (up_ready & ~ down_ready)
+            if (up_ready & ~enable)
                 buf_valid  <= up_valid;
 
-            if (down_ready)
+            if (enable)
                 down_valid <= up_ready ? up_valid : buf_valid;
 
-            up_ready <= down_ready;
+            up_ready <= enable;
         end
 
 endmodule

--- a/08_flow_control/08_07_a_plus_b_using_fifos_and_double_buffer/double_buffer_from_dally_harting.sv
+++ b/08_flow_control/08_07_a_plus_b_using_fifos_and_double_buffer/double_buffer_from_dally_harting.sv
@@ -22,15 +22,18 @@ module double_buffer_from_dally_harting
     output logic [width - 1:0] down_data
 );
 
+    logic               enable;
     logic               buf_valid;
     logic [width - 1:0] buf_data;
 
+    assign enable = down_ready | ~down_valid;
+
     always_ff @ (posedge clk)
     begin
-        if (up_ready & ~ down_ready)
+        if (up_ready & ~enable)
             buf_data <= up_data;
 
-        if (down_ready)
+        if (enable)
             down_data <= up_ready ? up_data : buf_data;
     end
 
@@ -43,13 +46,13 @@ module double_buffer_from_dally_harting
         end
         else
         begin
-            if (up_ready & ~ down_ready)
+            if (up_ready & ~enable)
                 buf_valid  <= up_valid;
 
-            if (down_ready)
+            if (enable)
                 down_valid <= up_ready ? up_valid : buf_valid;
 
-            up_ready <= down_ready;
+            up_ready <= enable;
         end
 
 endmodule


### PR DESCRIPTION
Насколько я понял материал 12ой лекции Школы Синтеза текущего сезона, Skid буфер является одним из возможных решений проблемы возникновения критического пути `ready` сигнала в конвейере:

<img width="1567" height="878" alt="valid-ready pipeline" src="https://github.com/user-attachments/assets/170f08de-c774-486f-8734-e50a1a575c64" />

Однако, в текущей реализации буфера в `up_ready` регистрируется не `down_ready | ~down_valid`, а `down_ready`, в связи с чем предлагаю свои правки